### PR TITLE
feature: Add variable for budget notification type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ In addition you have the option to:
 | role\_max\_session\_duration | Maximum CLI/API session duration | `string` | `"43200"` | no |
 | slack\_channel\_id | Sclack channel id to send budget notfication using AWS Chatbot | `string` | `""` | no |
 | slack\_workspace\_id | Sclack workspace id to send budget notfication using AWS Chatbot | `string` | `""` | no |
+| notification\_type | Budget notification type - The Forecast option is not available for Daily Budgets because the daily budgeted amount is always evaluated against the day before. | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In addition you have the option to:
 | role\_max\_session\_duration | Maximum CLI/API session duration | `string` | `"43200"` | no |
 | slack\_channel\_id | Sclack channel id to send budget notfication using AWS Chatbot | `string` | `""` | no |
 | slack\_workspace\_id | Sclack workspace id to send budget notfication using AWS Chatbot | `string` | `""` | no |
-| notification\_type | Budget notification type - The Forecast option is not available for Daily Budgets because the daily budgeted amount is always evaluated against the day before. | `string` | `""` | no |
+| notification\_type | Budget notification type - The Forecast option is not available for Daily Budgets because the daily budgeted amount is always evaluated against the day before. | `string` | `"ACTUAL"` | no |
 
 ## Outputs
 

--- a/_variables.tf
+++ b/_variables.tf
@@ -43,5 +43,8 @@ variable "slack_workspace_id" {
   description = "Sclack workspace id to send budget notfication using AWS Chatbot"
   default     = ""
 }
-
+variable "notification_type" {
+  description = "Budget notification type - The Forecast option is not available for Daily Budgets because the daily budgeted amount is always evaluated against the day before."
+  default     = "ACTUAL"
+}
 

--- a/budget.tf
+++ b/budget.tf
@@ -11,7 +11,7 @@ resource "aws_budgets_budget" "budget" {
     comparison_operator        = "GREATER_THAN"
     threshold                  = var.budget_threshold_percentage
     threshold_type             = "PERCENTAGE"
-    notification_type          = "${var.notification_type}"
+    notification_type          = var.notification_type
     subscriber_email_addresses = [var.budget_email]
     subscriber_sns_topic_arns  = [aws_sns_topic.budget_updates.*.arn[0]]
   }

--- a/budget.tf
+++ b/budget.tf
@@ -11,7 +11,7 @@ resource "aws_budgets_budget" "budget" {
     comparison_operator        = "GREATER_THAN"
     threshold                  = var.budget_threshold_percentage
     threshold_type             = "PERCENTAGE"
-    notification_type          = "FORECASTED"
+    notification_type          = "${var.notification_type}"
     subscriber_email_addresses = [var.budget_email]
     subscriber_sns_topic_arns  = [aws_sns_topic.budget_updates.*.arn[0]]
   }


### PR DESCRIPTION
- "ACTUAL" type is recommended as The Forecast option is not available for daily budgets and alerts are not performed daily as expected in most of the monitoring cases. If the "FORECAST" is a requirement use notification_type variable for this module.
### 
https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-create.html